### PR TITLE
Duplicate options when creating a client.

### DIFF
--- a/lib/oauth2/client.rb
+++ b/lib/oauth2/client.rb
@@ -30,6 +30,7 @@ module OAuth2
     # <tt>:access_token_url</tt> :: Specify the full URL of the access token endpoint.
     # <tt>:parse_json</tt> :: If true, <tt>application/json</tt> responses will be automatically parsed.
     def initialize(client_id, client_secret, opts = {})
+      opts            = opts.dup
       adapter         = opts.delete(:adapter)
       self.id         = client_id
       self.secret     = client_secret

--- a/spec/oauth2/client_spec.rb
+++ b/spec/oauth2/client_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 describe OAuth2::Client do
   subject do
-    cli = OAuth2::Client.new('abc', 'def', :site => 'https://api.example.com')
+    options = { :site => 'https://api.example.com' }.freeze
+
+    cli = OAuth2::Client.new('abc', 'def', options)
     cli.connection.build do |b|
       b.adapter :test do |stub|
         stub.get('/success')      { |env| [200, {'Content-Type' => 'text/awesome'}, 'yay'] }


### PR DESCRIPTION
Ran into an issue where my `:site` option was be deleted from an unfrozen constant after creating one client. This fixes it, as well as allows me to freeze my constants to ensure they aren't modified elsewhere.

Also removed a debugging statement in the tests while I was at it.
