### PR TITLE
Fixing an issue with the expiry key

### DIFF
--- a/lib/oauth2/strategy/web_server.rb
+++ b/lib/oauth2/strategy/web_server.rb
@@ -23,7 +23,7 @@ module OAuth2
 
         access   = params['access_token']
         refresh  = params['refresh_token']
-        expires_in = params['expires_in']
+        expires_in = params['expires']
         OAuth2::AccessToken.new(@client, access, refresh, expires_in, params)
       end
 


### PR DESCRIPTION
The query that returns from Facebook with the access_token also includes an expiry time; however, the key for that expiry time is now "expires", not "expires_in" as coded in web_server.rb. This single change fixes the auto-population of expiry time.
