### PR TITLE
Allow SSL options to be passed through to the connection

### DIFF
--- a/lib/oauth2/client.rb
+++ b/lib/oauth2/client.rb
@@ -29,13 +29,16 @@ module OAuth2
     # <tt>:access_token_path</tt> :: Specify the path to the access token endpoint.
     # <tt>:access_token_url</tt> :: Specify the full URL of the access token endpoint.
     # <tt>:parse_json</tt> :: If true, <tt>application/json</tt> responses will be automatically parsed.
+    # <tt>:ssl</tt> :: Specify SSL options for the connection.
     def initialize(client_id, client_secret, opts = {})
       adapter         = opts.delete(:adapter)
+      ssl_opts        = opts.delete(:ssl) || {}
+      connection_opts = ssl_opts ? {:ssl => ssl_opts} : {}
       self.id         = client_id
       self.secret     = client_secret
       self.site       = opts.delete(:site) if opts[:site]
       self.options    = opts
-      self.connection = Faraday::Connection.new(site)
+      self.connection = Faraday::Connection.new(site, connection_opts)
       self.json       = opts.delete(:parse_json)
 
       if adapter && adapter != :test

--- a/spec/oauth2/client_spec.rb
+++ b/spec/oauth2/client_spec.rb
@@ -27,6 +27,10 @@ describe OAuth2::Client do
     it 'should assign Faraday::Connection#host' do
       subject.connection.host.should == 'api.example.com'
     end
+
+    it 'should leave Faraday::Connection#ssl unset' do
+      subject.connection.ssl.should == {}
+    end
   end
 
   %w(authorize access_token).each do |path_type|
@@ -93,6 +97,20 @@ describe OAuth2::Client do
 
     after do
       subject.json = false
+    end
+  end
+
+  context 'with SSL options' do
+    subject do
+      cli = OAuth2::Client.new('abc', 'def', :site => 'https://api.example.com', :ssl => {:ca_file => 'foo.pem'})
+      cli.connection.build do |b|
+        b.adapter :test
+      end
+      cli
+    end
+
+    it 'should pass the SSL options along to Faraday::Connection#ssl' do
+      subject.connection.ssl.should == {:ca_file => 'foo.pem'}
     end
   end
 end


### PR DESCRIPTION
This small change allows SSL options (e.g. certificate verification mode) to be configured on the OAuth2::Client and passed through to the underlying Faraday connection.
