### PR TITLE
Allow to use the actiondispatch farady adapter for testing

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -65,6 +65,14 @@ mode, simply add the <tt>:parse_json</tt> option to your client initialization:
     # Obtain an access token using the client
     token.get('/some/url.json') # {"some" => "hash"}
 
+== Testing
+
+To use the OAuth2 client for testing error conditions do:
+
+    my_client.raise_errors = false
+    
+It will then return the error status and response instead of raising an exception.
+
 == Note on Patches/Pull Requests
  
 * Fork the project.

--- a/spec/oauth2/client_spec.rb
+++ b/spec/oauth2/client_spec.rb
@@ -6,7 +6,7 @@ describe OAuth2::Client do
     cli.connection.build do |b|
       b.adapter :test do |stub|
         stub.get('/success')      { |env| [200, {'Content-Type' => 'text/awesome'}, 'yay'] }
-        stub.get('/unauthorized') { |env| [401, {}, '']    }
+        stub.get('/unauthorized') { |env| [401, {'Content-Type' => 'text/plain'}, 'not authorized']    }
         stub.get('/error')        { |env| [500, {}, '']    }
         stub.get('/json')         { |env| [200, {'Content-Type' => 'application/json; charset=utf8'}, '{"abc":"def"}']}
       end
@@ -65,6 +65,15 @@ describe OAuth2::Client do
       response.should == 'yay'
       response.status.should == 200
       response.headers.should == {'Content-Type' => 'text/awesome'}
+    end
+    
+    it "returns ResponseString on error if raise_errors is false" do
+      subject.raise_errors = false
+      response = subject.request(:get, '/unauthorized', {}, {})
+      
+      response.should == 'not authorized'
+      response.status.should == 401
+      response.headers.should == {'Content-Type' => 'text/plain'}
     end
 
     it "raises OAuth2::AccessDenied on 401 response" do


### PR DESCRIPTION
In order to use the oauth2 client in (rails integration) tests it needs to be able to use the `Faraday::Adapter::ActionDispatch` adapter. This classe's `initialize` method expects a second argument, the test session. This patch allows you to pass that session to the adapter by passing an array with two elements to the `Client`'s initialize method.
