### PR TITLE
Fixes a parsing problem

### DIFF
--- a/lib/oauth2/strategy/web_server.rb
+++ b/lib/oauth2/strategy/web_server.rb
@@ -13,13 +13,16 @@ module OAuth2
       # endpoints.
       def get_access_token(code, options = {})
         response = @client.request(:post, @client.access_token_url, access_token_params(code, options))
-
-        params   = MultiJson.decode(response) rescue nil
-        # the ActiveSupport JSON parser won't cause an exception when
-        # given a formencoded string, so make sure that it was
-        # actually parsed in an Hash. This covers even the case where
-        # it caused an exception since it'll still be nil.
-        params   = Rack::Utils.parse_query(response) unless params.is_a? Hash
+        if response.is_a?(String)
+          params = MultiJson.decode(response) rescue nil
+          # the ActiveSupport JSON parser won't cause an exception when
+          # given a formencoded string, so make sure that it was
+          # actually parsed in an Hash. This covers even the case where
+          # it caused an exception since it'll still be nil.
+          params = Rack::Utils.parse_query(response) unless params.is_a? Hash
+        else
+          params = response
+        end
 
         access   = params['access_token']
         refresh  = params['refresh_token']


### PR DESCRIPTION
To be honest, I have no idea why JSON parsing happens twice in your code. Perhaps it depends on the HTTP client adapter? In `OAuth2::Client.request`, you use ResponseObject to translate the response if it's JSON. Then, in `OAuth2::Strategy::WebServer`, you seem to assume that the response is always a string, when in my case it is a `OAuth2::ResponseHash`. That seems redundant. My patch fixes the issue, but from what I can see, the whole parsing block in `WebServer` could be removed.
