### PR TITLE
Google API's HTTP 400 issue

### DIFF
--- a/lib/oauth2/strategy/web_server.rb
+++ b/lib/oauth2/strategy/web_server.rb
@@ -35,7 +35,7 @@ module OAuth2
 
       def access_token_params(code, options = {}) #:nodoc:
         super(options).merge({
-          'type' => 'web_server',
+          #eax: adding type parameter causes some oauth2 providers complain (i.e. see Google API's HTTP 400 issue). Merely, it should be added in options array if requested...
           'code' => code
         })
       end


### PR DESCRIPTION
Google oauth2 provider complains about adding type parameter...it expects just code, client_id, client_secret, grant and redirect uri parameters. Adding type automatically causes this. Let user add this parameter in options hash if badly requested...
