### PR TITLE
removed git and ruby 1.9 assumptions

### DIFF
--- a/spec/oauth2/client_spec.rb
+++ b/spec/oauth2/client_spec.rb
@@ -35,13 +35,13 @@ describe OAuth2::Client do
     it "should be able to pass parameters to the adapter, e.g. Faraday::Adapter::ActionDispatch" do
       connection = stub('connection')
       Faraday::Connection.stub(:new => connection)
-      session = stub('session', to_ary: nil)
+      session = stub('session', :to_ary => nil)
       builder = stub('builder')
       connection.stub(:build).and_yield(builder)
 
       builder.should_receive(:adapter).with(:action_dispatch, session)
 
-      OAuth2::Client.new('abc', 'def', adapter: [:action_dispatch, session])
+      OAuth2::Client.new('abc', 'def', :adapter => [:action_dispatch, session])
     end
   end
 


### PR DESCRIPTION
I've packaged up some tweaks to the gemspec and client_spec files that remove the assumption of git and ruby 1.9.
