### PR TITLE
:raise_error => false bug on initalize

### DIFF
--- a/lib/oauth2/client.rb
+++ b/lib/oauth2/client.rb
@@ -31,7 +31,7 @@ module OAuth2
       self.site         = self.options.delete(:site) if self.options[:site]
       self.connection   = Faraday::Connection.new(site, connection_opts)
       self.json         = self.options.delete(:parse_json)
-      self.raise_errors = self.options.delete(:raise_errors) || true
+      self.raise_errors = !(self.options.delete(:raise_errors) == false)
 
       if adapter && adapter != :test
         connection.build do |b|

--- a/spec/oauth2/client_spec.rb
+++ b/spec/oauth2/client_spec.rb
@@ -43,6 +43,17 @@ describe OAuth2::Client do
 
       OAuth2::Client.new('abc', 'def', :adapter => [:action_dispatch, session])
     end
+    
+    it "defaults raise_errors to true" do
+      subject.raise_errors.should be_true
+    end
+    
+    it "allows true/false for raise_errors option" do
+      client = OAuth2::Client.new('abc', 'def', :site => 'https://api.example.com', :raise_errors => false)
+      client.raise_errors.should be_false
+      client = OAuth2::Client.new('abc', 'def', :site => 'https://api.example.com', :raise_errors => true)
+      client.raise_errors.should be_true
+    end
   end
 
   %w(authorize access_token).each do |path_type|


### PR DESCRIPTION
Small bug fix on Client#initialize option.  
    self.options.delete(:raise_errors) || true

true is returned from the above statement when false is explicitly set as initialize option
