### PR TITLE
error when 204 no content

### DIFF
--- a/lib/oauth2/response_object.rb
+++ b/lib/oauth2/response_object.rb
@@ -51,7 +51,7 @@ module OAuth2
     include ResponseObject
 
     def initialize(response)
-      super(response.body)
+      super(response.body.to_s)
       self.response = response
     end
   end

--- a/spec/oauth2/access_token_spec.rb
+++ b/spec/oauth2/access_token_spec.rb
@@ -7,6 +7,7 @@ describe OAuth2::AccessToken do
       b.adapter :test do |stub|
         stub.get('/client?oauth_token=monkey')    {|env| [200, {}, 'get']}
         stub.post('/client')                      {|env| [200, {}, 'oauth_token=' << env[:body]['oauth_token']]}
+        stub.get('/empty_get?oauth_token=monkey') {|env| [204, {},  nil]}
         stub.put('/client')                       {|env| [200, {}, 'oauth_token=' << env[:body]['oauth_token']]}
         stub.delete('/client?oauth_token=monkey') {|env| [200, {}, 'delete']}
       end
@@ -40,6 +41,10 @@ describe OAuth2::AccessToken do
       it "makes #{http_method.upcase} requests with access token" do
         subject.send(http_method.to_sym, 'client').should == 'oauth_token=monkey'
       end
+    end
+    
+    it "works with a null response body" do
+      subject.get('empty_get').should == ''
     end
   end
 


### PR DESCRIPTION
OAuth2 raises an error when a server returns a status code of 204 and no content because the response body is nil. I have added a spec and fixed it.
