### PR TITLE
Loosen up the Faraday gem version requirement

### DIFF
--- a/oauth2.gemspec
+++ b/oauth2.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rspec', '~> 2.6'
   gem.add_development_dependency 'simplecov', '~> 0.4'
   gem.add_development_dependency 'yard', '~> 0.6.8'
-  gem.add_runtime_dependency 'faraday', '~> 0.7.0'
+  gem.add_runtime_dependency 'faraday', '~> 0.7'
   gem.add_runtime_dependency 'multi_json', '~> 1.0.0'
   gem.authors = ["Michael Bleigh", "Erik Michaels-Ober"]
   gem.description = %q{A Ruby wrapper for the OAuth 2.0 protocol built with a similar style to the original OAuth gem.}


### PR DESCRIPTION
Since Faraday is still under rapid development, restricting Faraday to the 0.7.x version range range isn't, from my perspective, a good idea. I loosed up the gem requirement so that oauth2 with work for any version of Faraday >= 0.7.0 and < 1.0.0.
