### PR TITLE
Passing options to client.get_token that is passed to AccessToken.

### DIFF
--- a/lib/oauth2/client.rb
+++ b/lib/oauth2/client.rb
@@ -115,8 +115,9 @@ module OAuth2
     # Initializes an AccessToken by making a request to the token endpoint
     #
     # @param [Hash] params a Hash of params for the token endpoint
+    # @param [Hash] access token options, to pass to the AccessToken object
     # @return [AccessToken] the initalized AccessToken
-    def get_token(params)
+    def get_token(params, access_token_opts={})
       opts = {:raise_errors => true, :parse => params.delete(:parse)}
       if options[:token_method] == :post
         opts[:body] = params
@@ -126,7 +127,7 @@ module OAuth2
       end
       response = request(options[:token_method], token_url, opts)
       raise Error.new(response) unless response.parsed.is_a?(Hash) && response.parsed['access_token']
-      AccessToken.from_hash(self, response.parsed)
+      AccessToken.from_hash(self, response.parsed.merge(access_token_opts))
     end
 
     # The Authorization Code strategy

--- a/lib/oauth2/strategy/auth_code.rb
+++ b/lib/oauth2/strategy/auth_code.rb
@@ -22,10 +22,11 @@ module OAuth2
       #
       # @param [String] code The Authorization Code value
       # @param [Hash] params additional params
+      # @param [Hash] opts options
       # @note that you must also provide a :redirect_uri with most OAuth 2.0 providers
-      def get_token(code, params={})
+      def get_token(code, params={}, opts={})
         params = {'grant_type' => 'authorization_code', 'code' => code}.merge(client_params).merge(params)
-        @client.get_token(params)
+        @client.get_token(params, opts)
       end
     end
   end

--- a/lib/oauth2/strategy/password.rb
+++ b/lib/oauth2/strategy/password.rb
@@ -16,11 +16,11 @@ module OAuth2
       # @param [String] username the End User username
       # @param [String] password the End User password
       # @param [Hash] params additional params
-      def get_token(username, password, params={})
+      def get_token(username, password, params={}, opts={})
         params = {'grant_type' => 'password',
                   'username'   => username,
                   'password'   => password}.merge(client_params).merge(params)
-        @client.get_token(params)
+        @client.get_token(params, opts)
       end
     end
   end


### PR DESCRIPTION
If you want to pass special options to AccessToken when created with for example auth_code.get_token that wasn't possible before. With this patch you don't need to initiate a new AccessToken object. This should fix bug #71

```
token = client.auth_code.get_token(code, {:redirect_uri => "http://localhost:4000"}, {:mode => :query, :param_name => "oauth_token"})
```
