### PR TITLE
Fix: authentication failed on www.yammer.com

### DIFF
--- a/lib/oauth2/access_token.rb
+++ b/lib/oauth2/access_token.rb
@@ -11,8 +11,8 @@ module OAuth2
       # @return [AccessToken] the initalized AccessToken
       def from_hash(client, hash)
         token = hash.delete('access_token') || hash.delete(:access_token)
-	if token.class == Hash
-	  token = token.delete('token') || token.delete(:token)
+        if token.class == Hash
+          token = token.delete('token') || token.delete(:token)
         end
         self.new(client, token, hash)
       end


### PR DESCRIPTION
I cannot use omniauth-yammer for www.yammer.com OAuth2 autentication but it fails.
Because yammer's access_token value is like hash not a string as follows

https://developer.yammer.com/api/oauth2.html
  "access_token": {
    "view_subscriptions": true,
    "expires_at": null,
    "authorized_at": "2011/04/06 16:25:46 +0000",
    "modify_subscriptions": true,
    "modify_messages": true,
    "network_permalink": "yammer-inc.com",
    "view_members": true,
    "view_tags": true,
    "network_id": 155465488,
    "user_id": 1014216,
    "view_groups": true,
    "token": "ajsdfiasd7f6asdf8o",
    "network_name": "Yammer",
    "view_messages": true,
    "created_at": "2011/04/06 16:25:46 +0000"
  },

I'm not familiar with OAuth2 specification but this patch fix this issue.

And also I create pull request to omniauth-yammer for removing overrode build_access_token.
