### PR TITLE
Don't redirect on 304 and 308

### DIFF
--- a/lib/oauth2/client.rb
+++ b/lib/oauth2/client.rb
@@ -91,9 +91,7 @@ module OAuth2
       response = Response.new(response, :parse => opts[:parse])
 
       case response.status
-      when 200..299, 304, 308
-        response
-      when 300..399
+      when 301, 302, 303, 307
         opts[:redirect_count] ||= 0
         opts[:redirect_count] += 1
         return response if opts[:redirect_count] > options[:max_redirects]
@@ -102,6 +100,9 @@ module OAuth2
           opts.delete(:body)
         end
         request(verb, response.headers['location'], opts)
+      when 200..299, 300..399
+        # on non-redirecting 3xx statuses, just return the response
+        response
       when 400..599
         e = Error.new(response)
         raise e if opts[:raise_errors] || options[:raise_errors]


### PR DESCRIPTION
Solves issue #96

When HTTP Status is 304, it's typically to respond to a If-Modified-Since header or similar. In this case no action should be taken, the resource to retrieve is already at the client side (otherwise she wouldn't have issued the request at all)

HTTP Status 308 (a Google extension) signals that a resumable request is correct, and gives in the 'Location' header the next url where to resume. This is used to upload files in chunks, and by no means the request should be repeated by the library. The user will make a new request with a new chunk of content, new Content-Range etc.
