### PR TITLE
symbolize ssl options when initializing client

### DIFF
--- a/lib/oauth2/client.rb
+++ b/lib/oauth2/client.rb
@@ -34,7 +34,7 @@ module OAuth2
                   :connection_build => block,
                   :max_redirects    => 5,
                   :raise_errors     => true}.merge(opts)
-      @options[:connection_opts][:ssl] = ssl if ssl
+      @options[:connection_opts][:ssl] = ssl.inject({}) {|h,(k,v)| h[k.to_sym] = v; h} if ssl
     end
 
     # Set the site host

--- a/spec/oauth2/client_spec.rb
+++ b/spec/oauth2/client_spec.rb
@@ -169,14 +169,14 @@ describe OAuth2::Client do
 
   context 'with SSL options' do
     subject do
-      cli = OAuth2::Client.new('abc', 'def', :site => 'https://api.example.com', :ssl => {:ca_file => 'foo.pem'})
+      cli = OAuth2::Client.new('abc', 'def', :site => 'https://api.example.com', :ssl => {'ca_file' => 'foo.pem'})
       cli.connection.build do |b|
         b.adapter :test
       end
       cli
     end
 
-    it 'should pass the SSL options along to Faraday::Connection#ssl' do
+    it 'should pass the symbolized SSL options along to Faraday::Connection#ssl' do
       subject.connection.ssl.should == {:ca_file => 'foo.pem'}
     end
   end


### PR DESCRIPTION
SSL options were not being symbolized properly even when they are correctly specified. For example:

``` ruby
provider :google_oauth2, 'key', 'secret', :client_options => {:ssl => {:verify => false}}
```

would create a client with `connection_opts` of

``` ruby
:ssl => {'verify' => false}
```

This fix normalizes options passed in so that Faraday can correctly pick up the correct options
