### PR TITLE
Expose the oauth2 HTTP headers so we can use them outside of this oauth2 package

### DIFF
--- a/lib/oauth2/access_token.rb
+++ b/lib/oauth2/access_token.rb
@@ -126,12 +126,17 @@ module OAuth2
       request(:delete, path, opts, &block)
     end
 
+    # Get the headers hash (includes Authorization token)
+    def headers
+      { 'Authorization' => options[:header_format] % token }
+    end
+
   private
     def set_token(opts)
       case options[:mode]
       when :header
         opts[:headers] ||= {}
-        opts[:headers]['Authorization'] = options[:header_format] % token
+        opts[:headers].merge!(headers)
       when :query
         opts[:params] ||= {}
         opts[:params][options[:param_name]] = token


### PR DESCRIPTION
- So a user can use the auth2 token after a successful authentication without
  needing to wait for ruby's oauth2 package to support it.
  
    Example:
  
  client = OAuth2::Client.new(CLIENT_ID, '',
                              :site => HOST_PREFIX,
                              :token_url => '/oauth/token')
  
  token = client.password.get_token(username, password, :scope => 'read')
  
  conn = Faraday.new(HOST_PREFIX) do |builder|
    builder.request :multipart
    builder.adapter :net_http
  end
  
  body = {
      :name => name,
    :description => description || "no description",
    :file => Faraday::UploadIO.new(zip_file, 'application/zip')
  }
  
  url = conn.build_url(url).to_s
  
    # Request a response, and specify the auth headers
  response = run_request(:post, url, body, token.headers)
