### PR TITLE
Relaxed unnecessarily strict rack dependency to ~> 1.2

### DIFF
--- a/oauth2.gemspec
+++ b/oauth2.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'faraday', '~> 0.8'
   gem.add_dependency 'httpauth', '~> 0.1'
   gem.add_dependency 'multi_json', '~> 1.0'
-  gem.add_dependency 'rack', '~> 1.4'
+  gem.add_dependency 'rack', '~> 1.2'
   gem.add_dependency 'jwt', '~> 0.1.4'
   gem.add_development_dependency 'addressable'
   gem.add_development_dependency 'multi_xml'


### PR DESCRIPTION
oauth2 uses 2 methods in the Rack gem, both of which are located in lib/rack/utils.rb. The comparison at https://github.com/rack/rack/compare/2ed515786322059f568c8a9df77a6e4b70f09225...e932c585dd1c97e504697c41ce9a4d638275ae02 shows that the only changes between 1.2 and 1.4 in these methods are performance improvements or security updates which are not relevant here, as we are not acting as a server.
