### PR TITLE
Fix refresh token behavior.

### DIFF
--- a/lib/oauth2/access_token.rb
+++ b/lib/oauth2/access_token.rb
@@ -1,7 +1,7 @@
 module OAuth2
   class AccessToken
-    attr_reader :client, :token, :refresh_token, :expires_in, :expires_at, :params
-    attr_accessor :options
+    attr_reader :client, :token, :expires_in, :expires_at, :params
+    attr_accessor :options, :refresh_token
 
     class << self
       # Initializes an AccessToken from a Hash
@@ -84,6 +84,7 @@ module OAuth2
                     :refresh_token  => refresh_token)
       new_token = @client.get_token(params)
       new_token.options = options
+      new_token.refresh_token = refresh_token unless new_token.refresh_token
       new_token
     end
 

--- a/spec/oauth2/access_token_spec.rb
+++ b/spec/oauth2/access_token_spec.rb
@@ -132,13 +132,26 @@ describe AccessToken do
   end
 
   describe "#refresh!" do
+    let(:access) {
+      AccessToken.new(client, token, :refresh_token  => 'abaca',
+                                     :expires_in     => 600,
+                                     :param_name     => 'o_param')
+    }
+
     it "returns a refresh token with appropriate values carried over" do
-      access = AccessToken.new(client, token, :refresh_token  => 'abaca',
-                                              :expires_in     => 600,
-                                              :param_name     => 'o_param')
       refreshed = access.refresh!
       expect(access.client).to eq(refreshed.client)
       expect(access.options[:param_name]).to eq(refreshed.options[:param_name])
+    end
+
+    context "with a nil refresh_token in the response" do
+      let(:refresh_body) { MultiJson.encode(:access_token => 'refreshed_foo', :expires_in => 600, :refresh_token => nil) }
+
+      it "copies the refresh_token from the original token" do
+        refreshed = access.refresh!
+
+        expect(refreshed.refresh_token).to eq(access.refresh_token)
+      end
     end
   end
 end


### PR DESCRIPTION
If a refresh token isn't returned on a refresh response,
copy it over from the existing token. Google only returns
the refresh token when a user explicitly clicks to authorize,
so every subsequent time, it's not included. I think it
makes more sense to maintain all relevant attributes of
the token when it gets refreshed, and this includes the
refresh token.
