### PR TITLE
Removing warning related to hiding the accessor.

### DIFF
--- a/lib/oauth2/client.rb
+++ b/lib/oauth2/client.rb
@@ -3,8 +3,9 @@ require 'faraday'
 module OAuth2
   # The OAuth2::Client class
   class Client
-    attr_reader :id, :secret
-    attr_accessor :site, :connection, :options
+    attr_reader :id, :secret, :site
+    attr_accessor :options
+    attr_writer :connection
 
     # Instantiate a new OAuth 2.0 client using the
     # Client ID and Client Secret registered to your


### PR DESCRIPTION
Small change that removes a warning when running on Ruby 1.9.2. The definitions of some methods override the definition created by the attr_accessor. This can be fixed by simply using just the reader and just the writer, then there is no warning and no hiding either.
