### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ the entire specification over time.
 
 ## Usage Examples
     require 'oauth2'
-    client = OAuth2::Client.new('client_id', 'client_secret', :site => 'https://example.org')
-
+    client = OAuth2::Client.new('client_id', 'client_secret')
+    client.site =  'https://example.org'
+    
     client.auth_code.authorize_url(:redirect_uri => 'http://localhost:8080/oauth2/callback')
     # => "https://example.org/oauth/authorization?response_type=code&client_id=client_id&redirect_uri=http://localhost:8080/oauth2/callback"
 


### PR DESCRIPTION
Currently there's a change on the client's options, and the example is not working. If you see https://github.com/intridea/oauth2/blame/master/lib/oauth2/client.rb#L29, the site option is deleted. If I want to set the site I have to use the site method.
