### PR TITLE
Form-Encoded Body Parameter was finally set to "access_token" in RFC6750

### DIFF
--- a/lib/oauth2/access_token.rb
+++ b/lib/oauth2/access_token.rb
@@ -34,7 +34,7 @@ module OAuth2
     # @option opts [Symbol] :mode (:header) the transmission mode of the Access Token parameter value
     #    one of :header, :body or :query
     # @option opts [String] :header_format ('Bearer %s') the string format to use for the Authorization header
-    # @option opts [String] :param_name ('bearer_token') the parameter name to use for transmission of the
+    # @option opts [String] :param_name ('access_token') the parameter name to use for transmission of the
     #    Access Token value in :body or :query transmission mode
     def initialize(client, token, opts={})
       @client = client
@@ -47,7 +47,7 @@ module OAuth2
       @expires_at ||= Time.now.to_i + @expires_in if @expires_in
       @options = {:mode          => opts.delete(:mode) || :header,
                   :header_format => opts.delete(:header_format) || 'Bearer %s',
-                  :param_name    => opts.delete(:param_name) || 'bearer_token'}
+                  :param_name    => opts.delete(:param_name) || 'access_token'}
       @params = opts
     end
 

--- a/spec/oauth2/access_token_spec.rb
+++ b/spec/oauth2/access_token_spec.rb
@@ -12,7 +12,7 @@ describe AccessToken do
       builder.adapter :test do |stub|
         VERBS.each do |verb|
           stub.send(verb, '/token/header') {|env| [200, {}, env[:request_headers]['Authorization']]}
-          stub.send(verb, "/token/query?bearer_token=#{token}") {|env| [200, {}, Addressable::URI.parse(env[:url]).query_values['bearer_token']]}
+          stub.send(verb, "/token/query?access_token=#{token}") {|env| [200, {}, Addressable::URI.parse(env[:url]).query_values['access_token']]}
           stub.send(verb, '/token/body') {|env| [200, {}, env[:body]]}
         end
         stub.post('/oauth/token') {|env| [200, {'Content-Type' => 'application/json'}, refresh_body]}


### PR DESCRIPTION
See http://tools.ietf.org/html/rfc6750#section-2.2
