### PR TITLE
Convert expires_at to integer

### DIFF
--- a/lib/oauth2/access_token.rb
+++ b/lib/oauth2/access_token.rb
@@ -44,6 +44,7 @@ module OAuth2
       end
       @expires_in ||= opts.delete('expires')
       @expires_in &&= @expires_in.to_i
+      @expires_at &&= @expires_at.to_i
       @expires_at ||= Time.now.to_i + @expires_in if @expires_in
       @options = {:mode          => opts.delete(:mode) || :header,
                   :header_format => opts.delete(:header_format) || 'Bearer %s',

--- a/spec/oauth2/access_token_spec.rb
+++ b/spec/oauth2/access_token_spec.rb
@@ -59,6 +59,13 @@ describe AccessToken do
       target.options[:header_format].should == 'Bearer %'
       target.options[:mode].should == :body
     end
+    
+    it "initializes with a string expires_at" do
+      hash = {:access_token => token, :expires_at => '1361396829', 'foo' => 'bar'}
+      target = AccessToken.from_hash(client, hash)
+      assert_initialized_token(target)
+      expect(target.expires_at).to be_a(Integer)
+    end
   end
 
   describe '#request' do


### PR DESCRIPTION
We're using the google-oauth2 gem with oauth2 and devise, and recently google have started supplying the expires_at value. Since this is a string, oauth2 explodes when trying to evaluate if a token has exploded (string doesn't implement the < operator).

So like you've done with expires_in, we convert it to an integer. We've written tests and she's all green.

Note that we're using 0.8.0 because of https://github.com/intridea/omniauth-oauth2/issues/20 but this cleanly applies to HEAD as well.
