### PR TITLE
Don't depend on the HTTPAuth Gem.

### DIFF
--- a/lib/oauth2/strategy/assertion.rb
+++ b/lib/oauth2/strategy/assertion.rb
@@ -1,4 +1,3 @@
-require 'httpauth'
 require 'jwt'
 
 module OAuth2

--- a/lib/oauth2/strategy/client_credentials.rb
+++ b/lib/oauth2/strategy/client_credentials.rb
@@ -1,4 +1,4 @@
-require 'httpauth'
+require 'base64'
 
 module OAuth2
   module Strategy
@@ -20,8 +20,16 @@ module OAuth2
       def get_token(params={}, opts={})
         request_body = opts.delete('auth_scheme') == 'request_body'
         params.merge!('grant_type' => 'client_credentials')
-        params.merge!(request_body ? client_params : {:headers => {'Authorization' => HTTPAuth::Basic.pack_authorization(client_params['client_id'], client_params['client_secret'])}})
+        params.merge!(request_body ? client_params : {:headers => {'Authorization' => authorization(client_params['client_id'], client_params['client_secret'])}})
         @client.get_token(params, opts.merge('refresh_token' => nil))
+      end
+
+      # Returns the Authorization header value for Basic Authentication
+      #
+      # @param [String] The client ID
+      # @param [String] the client secret
+      def authorization(client_id, client_secret)
+        'Basic ' + Base64.encode64(client_id + ':' + client_secret).gsub("\n", '')
       end
     end
   end

--- a/oauth2.gemspec
+++ b/oauth2.gemspec
@@ -6,7 +6,6 @@ require 'oauth2/version'
 Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.0'
   spec.add_dependency 'faraday', '~> 0.8'
-  spec.add_dependency 'httpauth', '~> 0.2'
   spec.add_dependency 'multi_json', '~> 1.0'
   spec.add_dependency 'multi_xml', '~> 0.5'
   spec.add_dependency 'rack', '~> 1.2'


### PR DESCRIPTION
HTTP Basic Authentication is basically a one-liner and it's a waste to depend
on a Gem for this functionality.

Another reason not to depend on HTTPAuth is that it's no longer maintained.
