### PR TITLE
Endpoints are not _known as_ Facebook. They _might be_ Facebook.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 A Ruby wrapper for the OAuth 2.0 specification. This is a work in progress,
 being built first to solve the pragmatic process of connecting to existing
-OAuth 2.0 endpoints (a.k.a. Facebook) with the goal of building it up to meet
+OAuth 2.0 endpoints (e.g. Facebook) with the goal of building it up to meet
 the entire specification over time.
 
 ## Installation


### PR DESCRIPTION
This corrects an issue of understanding the intention of the library correctly, by correcting _a.k.a._ to _e.g._.
