### PR TITLE
Reduce rack version requirement

### DIFF
--- a/oauth2.gemspec
+++ b/oauth2.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday', '~> 0.8'
   spec.add_dependency 'multi_json', '~> 1.0'
   spec.add_dependency 'multi_xml', '~> 0.5'
-  spec.add_dependency 'rack', '~> 1.2'
+  spec.add_dependency 'rack', '>= 0.1'
   spec.add_dependency 'jwt', '~> 0.1.4'
   spec.authors       = ["Michael Bleigh", "Erik Michaels-Ober"]
   spec.cert_chain    = %w(certs/sferik.pem)


### PR DESCRIPTION
I would like to relax the rack requirement to allow for using this gem in Rails 2.3.X projects.

PR #110 pointed out that the gem only uses 2 methods from the Rack gem; `escape` and `parse_query`. A [search for rack](https://github.com/intridea/oauth2/search?q=rack) shows only calling the methods with a single parameter each. Both of these method signatures were introduced via commit https://github.com/rack/rack/commit/7ed819ad716661a67ada21d04e7815e493ccdb9d for version `0.1` of Rack.

This is a change of the gemspec's version for rack to be `'>= 0.1'`.
