### PR TITLE
Ruby 1.8 / 1.9 compat: mime-types >= 2 depends on Ruby >= 2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'rdoc'
 group :test do
   gem 'addressable'
   gem 'coveralls', :require => false
+  gem 'mime-types', '< 2'
   gem 'rspec', '>= 2.14'
   gem 'simplecov', :require => false
 end


### PR DESCRIPTION
The README claims compatibility with Ruby < 2, but the newest coveralls by default pulls in mime-types v2 which is only compatible with Ruby >= 2. So I'd suggest pinning it to < 2, as done here.
