### PR TITLE
Allow jwt 1.0.0 to be used as a dependency

### DIFF
--- a/oauth2.gemspec
+++ b/oauth2.gemspec
@@ -5,7 +5,7 @@ require 'oauth2/version'
 
 Gem::Specification.new do |spec|
   spec.add_dependency 'faraday', ['>= 0.8', '< 0.10']
-  spec.add_dependency 'jwt', '~> 0.1.8'
+  spec.add_dependency 'jwt', ['>= 0.1.8', '< 1.1.0']
   spec.add_dependency 'multi_json', '~> 1.3'
   spec.add_dependency 'multi_xml', '~> 0.5'
   spec.add_dependency 'rack', '~> 1.2'


### PR DESCRIPTION
Loosens the previous restriction to allow jwt ~> 1.0.0 to be used as a dependency.

Resolves #171
