### PR TITLE
Fix deprecation warning and assorted Rubocop violations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  Includes:
+  Include:
     - 'Gemfile'
     - 'Rakefile'
     - 'oauth2.gemspec'

--- a/lib/oauth2/client.rb
+++ b/lib/oauth2/client.rb
@@ -25,18 +25,18 @@ module OAuth2
     #  on responses with 400+ status codes
     # @yield [builder] The Faraday connection builder
     def initialize(client_id, client_secret, opts = {}, &block)
-      _opts = opts.dup
+      dup_opts = opts.dup
       @id = client_id
       @secret = client_secret
-      @site = _opts.delete(:site)
-      ssl = _opts.delete(:ssl)
+      @site = dup_opts.delete(:site)
+      ssl = dup_opts.delete(:ssl)
       @options = {:authorize_url    => '/oauth/authorize',
                   :token_url        => '/oauth/token',
                   :token_method     => :post,
                   :connection_opts  => {},
                   :connection_build => block,
                   :max_redirects    => 5,
-                  :raise_errors     => true}.merge(_opts)
+                  :raise_errors     => true}.merge(dup_opts)
       @options[:connection_opts][:ssl] = ssl if ssl
     end
 

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -24,7 +24,7 @@ end
 
 Faraday.default_adapter = :test
 
-RSpec.configure do |conf|
+RSpec.configure do
   include OAuth2
 end
 

--- a/spec/oauth2/access_token_spec.rb
+++ b/spec/oauth2/access_token_spec.rb
@@ -15,7 +15,7 @@ describe AccessToken do
           stub.send(verb, "/token/query?access_token=#{token}") { |env| [200, {}, Addressable::URI.parse(env[:url]).query_values['access_token']] }
           stub.send(verb, '/token/body') { |env| [200, {}, env[:body]] }
         end
-        stub.post('/oauth/token') { |env| [200, {'Content-Type' => 'application/json'}, refresh_body] }
+        stub.post('/oauth/token') { [200, {'Content-Type' => 'application/json'}, refresh_body] }
       end
     end
   end
@@ -25,7 +25,7 @@ describe AccessToken do
   describe '#initialize' do
     it 'assigns client and token' do
       expect(subject.client).to eq(client)
-      expect(subject.token).to  eq(token)
+      expect(subject.token).to eq(token)
     end
 
     it 'assigns extra params' do

--- a/spec/oauth2/client_spec.rb
+++ b/spec/oauth2/client_spec.rb
@@ -7,15 +7,15 @@ describe OAuth2::Client do
   subject do
     OAuth2::Client.new('abc', 'def', :site => 'https://api.example.com') do |builder|
       builder.adapter :test do |stub|
-        stub.get('/success')      { |env| [200, {'Content-Type' => 'text/awesome'}, 'yay'] }
+        stub.get('/success')      { [200, {'Content-Type' => 'text/awesome'}, 'yay'] }
         stub.get('/reflect')      { |env| [200, {}, env[:body]] }
         stub.post('/reflect')     { |env| [200, {}, env[:body]] }
-        stub.get('/unauthorized') { |env| [401, {'Content-Type' => 'application/json'}, MultiJson.encode(:error => error_value, :error_description => error_description_value)] }
-        stub.get('/conflict')     { |env| [409, {'Content-Type' => 'text/plain'}, 'not authorized'] }
-        stub.get('/redirect')     { |env| [302, {'Content-Type' => 'text/plain', 'location' => '/success'}, ''] }
-        stub.post('/redirect')    { |env| [303, {'Content-Type' => 'text/plain', 'location' => '/reflect'}, ''] }
-        stub.get('/error')        { |env| [500, {'Content-Type' => 'text/plain'}, 'unknown error'] }
-        stub.get('/empty_get')    { |env| [204, {}, nil] }
+        stub.get('/unauthorized') { [401, {'Content-Type' => 'application/json'}, MultiJson.encode(:error => error_value, :error_description => error_description_value)] }
+        stub.get('/conflict')     { [409, {'Content-Type' => 'text/plain'}, 'not authorized'] }
+        stub.get('/redirect')     { [302, {'Content-Type' => 'text/plain', 'location' => '/success'}, ''] }
+        stub.post('/redirect')    { [303, {'Content-Type' => 'text/plain', 'location' => '/reflect'}, ''] }
+        stub.get('/error')        { [500, {'Content-Type' => 'text/plain'}, 'unknown error'] }
+        stub.get('/empty_get')    { [204, {}, nil] }
       end
     end
   end
@@ -65,7 +65,7 @@ describe OAuth2::Client do
     it 'allows override of raise_errors option' do
       client = OAuth2::Client.new('abc', 'def', :site => 'https://api.example.com', :raise_errors => true) do |builder|
         builder.adapter :test do |stub|
-          stub.get('/notfound') { |env| [404, {}, nil] }
+          stub.get('/notfound') { [404, {}, nil] }
         end
       end
       expect(client.options[:raise_errors]).to be true

--- a/spec/oauth2/strategy/assertion_spec.rb
+++ b/spec/oauth2/strategy/assertion_spec.rb
@@ -5,7 +5,7 @@ describe OAuth2::Strategy::Assertion do
     cli = OAuth2::Client.new('abc', 'def', :site => 'http://api.example.com')
     cli.connection.build do |b|
       b.adapter :test do |stub|
-        stub.post('/oauth/token') do |env|
+        stub.post('/oauth/token') do
           case @mode
           when 'formencoded'
             [200, {'Content-Type' => 'application/x-www-form-urlencoded'}, 'expires_in=600&access_token=salmon&refresh_token=trout']

--- a/spec/oauth2/strategy/auth_code_spec.rb
+++ b/spec/oauth2/strategy/auth_code_spec.rb
@@ -9,7 +9,7 @@ describe OAuth2::Strategy::AuthCode do
   let(:client) do
     OAuth2::Client.new('abc', 'def', :site => 'http://api.example.com') do |builder|
       builder.adapter :test do |stub|
-        stub.get("/oauth/token?client_id=abc&client_secret=def&code=#{code}&grant_type=authorization_code") do |env|
+        stub.get("/oauth/token?client_id=abc&client_secret=def&code=#{code}&grant_type=authorization_code") do
           case @mode
           when 'formencoded'
             [200, {'Content-Type' => 'application/x-www-form-urlencoded'}, kvform_token]
@@ -19,7 +19,7 @@ describe OAuth2::Strategy::AuthCode do
             [200, {'Content-Type' => 'application/x-www-form-urlencoded'}, facebook_token]
           end
         end
-        stub.post('/oauth/token', 'client_id' => 'abc', 'client_secret' => 'def', 'code' => 'sushi', 'grant_type' => 'authorization_code') do |env|
+        stub.post('/oauth/token', 'client_id' => 'abc', 'client_secret' => 'def', 'code' => 'sushi', 'grant_type' => 'authorization_code') do
           case @mode
           when 'formencoded'
             [200, {'Content-Type' => 'application/x-www-form-urlencoded'}, kvform_token]

--- a/spec/oauth2/strategy/client_credentials_spec.rb
+++ b/spec/oauth2/strategy/client_credentials_spec.rb
@@ -17,7 +17,7 @@ describe OAuth2::Strategy::ClientCredentials do
             [200, {'Content-Type' => 'application/json'}, json_token]
           end
         end
-        stub.post('/oauth/token', 'client_id' => 'abc', 'client_secret' => 'def', 'grant_type' => 'client_credentials') do |env|
+        stub.post('/oauth/token', 'client_id' => 'abc', 'client_secret' => 'def', 'grant_type' => 'client_credentials') do
           case @mode
           when 'formencoded'
             [200, {'Content-Type' => 'application/x-www-form-urlencoded'}, kvform_token]

--- a/spec/oauth2/strategy/password_spec.rb
+++ b/spec/oauth2/strategy/password_spec.rb
@@ -5,7 +5,7 @@ describe OAuth2::Strategy::Password do
     cli = OAuth2::Client.new('abc', 'def', :site => 'http://api.example.com')
     cli.connection.build do |b|
       b.adapter :test do |stub|
-        stub.post('/oauth/token') do |env|
+        stub.post('/oauth/token') do
           case @mode
           when 'formencoded'
             [200, {'Content-Type' => 'application/x-www-form-urlencoded'}, 'expires_in=600&access_token=salmon&refresh_token=trout']


### PR DESCRIPTION
There are a number of Rubocop violations that are causing the build to fail.  Fixed a deprecation warning in the .rubocop.yml and then fixed those violations.
