### PR TITLE
Allow alternate Authorization header field names

### DIFF
--- a/lib/oauth2/access_token.rb
+++ b/lib/oauth2/access_token.rb
@@ -34,6 +34,8 @@ module OAuth2
     # @option opts [Symbol] :mode (:header) the transmission mode of the Access Token parameter value
     #    one of :header, :body or :query
     # @option opts [String] :header_format ('Bearer %s') the string format to use for the Authorization header
+    # @option opts [String] :header_auth_field ('Authorization') the name of the Authorization header field
+    #    containing the token value
     # @option opts [String] :param_name ('access_token') the parameter name to use for transmission of the
     #    Access Token value in :body or :query transmission mode
     def initialize(client, token, opts = {})
@@ -46,9 +48,10 @@ module OAuth2
       @expires_in &&= @expires_in.to_i
       @expires_at &&= @expires_at.to_i
       @expires_at ||= Time.now.to_i + @expires_in if @expires_in
-      @options = {:mode          => opts.delete(:mode) || :header,
-                  :header_format => opts.delete(:header_format) || 'Bearer %s',
-                  :param_name    => opts.delete(:param_name) || 'access_token'}
+      @options = {:mode              => opts.delete(:mode) || :header,
+                  :header_format     => opts.delete(:header_format) || 'Bearer %s',
+                  :header_auth_field => opts.delete(:header_auth_field) || 'Authorization',
+                  :param_name        => opts.delete(:param_name) || 'access_token'}
       @params = opts
     end
 
@@ -144,7 +147,7 @@ module OAuth2
 
     # Get the headers hash (includes Authorization token)
     def headers
-      {'Authorization' => options[:header_format] % token}
+      {options[:header_auth_field] => options[:header_format] % token}
     end
 
   private


### PR DESCRIPTION
Working with SugarCRM's REST API requires an authorization field header of "OAuth-Token" instead of "Authorization".  I needed to be able to do something like this (last line below is the important one, where I just added a new option, header_auth_field):

``` ruby
client = OAuth2::Client.new client_id, client_secret, :token_url => '/rest/v10/oauth2/token', :site => client_url
token_request = client.password.get_token(username, password)
token_string = token_request.token
request = OAuth2::AccessToken.new client, token_string, :header_format => "%s", :header_auth_field => "OAuth-Token"
```
