### PR TITLE
Remove circular reference for OAuth2::Error

### DIFF
--- a/lib/oauth2/error.rb
+++ b/lib/oauth2/error.rb
@@ -5,7 +5,6 @@ module OAuth2
     # standard error values include:
     # :invalid_request, :invalid_client, :invalid_token, :invalid_grant, :unsupported_grant_type, :invalid_scope
     def initialize(response)
-      response.error = self
       @response = response
 
       message = []


### PR DESCRIPTION
OAuth2::Error contains response and adds a link to itself from response. This is a circular reference and it can lead to various problems. E.g., attempt to dump exception to json (that most exception handlers are doing) will lead to `ActiveSupport::JSON::Encoding::CircularReferenceError: object references itself`.

This is why I propose to remove this inter-dependency.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/intridea/oauth2/201)

<!-- Reviewable:end -->
