### PR TITLE
Fix for circular reference exceptions between Error and Response classes

### DIFF
--- a/lib/oauth2/client.rb
+++ b/lib/oauth2/client.rb
@@ -115,7 +115,6 @@ module OAuth2
       when 400..599
         error = Error.new(response)
         raise(error) if opts.fetch(:raise_errors, options[:raise_errors])
-        response.error = error
         response
       else
         error = Error.new(response)

--- a/lib/oauth2/error.rb
+++ b/lib/oauth2/error.rb
@@ -5,7 +5,6 @@ module OAuth2
     # standard error codes include:
     # 'invalid_request', 'invalid_client', 'invalid_token', 'invalid_grant', 'unsupported_grant_type', 'invalid_scope'
     def initialize(response)
-      response.error = self
       @response = response
       message_opts = {}
 

--- a/lib/oauth2/response.rb
+++ b/lib/oauth2/response.rb
@@ -6,7 +6,7 @@ module OAuth2
   # OAuth2::Response class
   class Response
     attr_reader :response
-    attr_accessor :error, :options
+    attr_accessor :options
 
     # Procs that, when called, will parse a response body according
     # to the specified format.

--- a/spec/oauth2/client_spec.rb
+++ b/spec/oauth2/client_spec.rb
@@ -284,7 +284,6 @@ RSpec.describe OAuth2::Client do
 
       expect(response.status).to eq(401)
       expect(response.headers).to eq('Content-Type' => 'application/json')
-      expect(response.error).not_to be_nil
     end
 
     %w[/unauthorized /conflict /error /different_encoding /ascii_8bit_encoding].each do |error_path|
@@ -315,7 +314,7 @@ RSpec.describe OAuth2::Client do
       begin
         subject.request(:get, '/error')
       rescue StandardError => e
-        expect(e.response).not_to be_nil
+        expect(e.response).to be_a(OAuth2::Response)
         expect(e.to_s).to match(/unknown error/)
       end
     end

--- a/spec/oauth2/error_spec.rb
+++ b/spec/oauth2/error_spec.rb
@@ -15,12 +15,6 @@ RSpec.describe OAuth2::Error do
   let(:response_headers) { {'Content-Type' => 'application/json'} }
   let(:response_body) { {:text => 'Coffee brewing failed'}.to_json }
 
-  it 'sets self to #error on the response object' do
-    expect(response.error).to be_nil
-    error = described_class.new(response)
-    expect(response.error).to equal(error)
-  end
-
   it 'sets the response object to #response on self' do
     error = described_class.new(response)
     expect(error.response).to equal(response)

--- a/spec/oauth2/response_spec.rb
+++ b/spec/oauth2/response_spec.rb
@@ -199,10 +199,6 @@ RSpec.describe OAuth2::Response do
   end
 
   describe 'converting to json' do
-    before do
-      OAuth2::Error.new(subject)
-    end
-
     it 'does not blow up' do
       expect { subject.to_json }.not_to raise_error
     end


### PR DESCRIPTION
This is to replace https://github.com/oauth-xx/oauth2/pull/201.  This is a breaking change!  It removes the ability to call `.error` from an `OAuth2::Response` object.

Also, adding some test coverage and fixing a potential 500 if a response is encountered with no headers.  The `Response` class was calling `response.headers.values_at` without checking to see if `response.headers` returned a valid thing, and also there were no tests for `#content_type`.

As an aside, the exception referenced in that older pull request only is a thing in [older versions of Rails](https://apidock.com/rails/ActiveSupport/JSON/Encoding/CircularReferenceError).  The current version of ActiveSupport JSON encoding says:

```
"The JSON encoder in Rails 4.1 no longer offers protection from circular references. " \
"You are seeing this warning because you are rescuing from (or otherwise referencing) " \
"ActiveSupport::Encoding::CircularReferenceError. In the future, this error will be " \
"removed from Rails. You should remove these rescue blocks from your code and ensure " \
"that your data structures are free of circular references so they can be properly " \
"serialized into JSON.\n\n" \
"For example, the following Hash contains a circular reference to itself:\n" \
"   h = {}\n" \
"   h['circular'] = h\n" \
"In this case, calling h.to_json would not work properly."
```

It is likely not ideal to raise stack level too deep levels _either_, but from a practical testing standpoint it is not a good idea to detect the presence of that old error.