### PR TITLE
Support revocation with URL-encoded parameters

### DIFF
--- a/.rubocop_gradual.lock
+++ b/.rubocop_gradual.lock
@@ -37,7 +37,7 @@
     [69, 15, 38, "RSpec/ContextWording: Context description should match /^when\\b/, /^with\\b/, or /^without\\b/.", 1480816240],
     [79, 13, 23, "RSpec/ContextWording: Context description should match /^when\\b/, /^with\\b/, or /^without\\b/.", 2314399065]
   ],
-  "spec/oauth2/client_spec.rb:3334307042": [
+  "spec/oauth2/client_spec.rb:292714281": [
     [6, 1, 29, "RSpec/SpecFilePathFormat: Spec path should end with `o_auth2/client*_spec.rb`.", 439549885],
     [175, 7, 492, "RSpec/NoExpectationExample: No expectation found in this example.", 1272021224],
     [194, 7, 592, "RSpec/NoExpectationExample: No expectation found in this example.", 3428877205],

--- a/lib/oauth2/client.rb
+++ b/lib/oauth2/client.rb
@@ -256,10 +256,10 @@ module OAuth2
     # @see https://datatracker.ietf.org/doc/html/rfc7009#section-2.1
     def revoke_token(token, token_type_hint = nil, params = {}, &block)
       params[:token_method] ||= :post_with_query_string
+      params[:token] = token
+      params[:token_type_hint] = token_type_hint if token_type_hint
+
       req_opts = params_to_req_opts(params)
-      req_opts[:params] ||= {}
-      req_opts[:params][:token] = token
-      req_opts[:params][:token_type_hint] = token_type_hint if token_type_hint
 
       request(http_method, revoke_url, req_opts, &block)
     end


### PR DESCRIPTION
Fixes https://github.com/ruby-oauth/oauth2/issues/655