### PR TITLE
Add verb-dependent token mode

### DIFF
--- a/spec/oauth2/access_token_spec.rb
+++ b/spec/oauth2/access_token_spec.rb
@@ -411,6 +411,26 @@ RSpec.describe OAuth2::AccessToken do
         end
       end
 
+      context "with verb-dependent mode" do
+        let(:mode) do
+          lambda do |verb|
+            case verb
+            when :get then :query
+            when :post, :delete then :header
+            when :put, :patch then :body
+            end
+          end
+        end
+
+        let(:options) { {mode:} }
+
+        VERBS.each do |verb|
+          it "correctly handles a #{verb.to_s.upcase}" do
+            expect(subject.__send__(verb, "/token/#{mode.call(verb)}").body).to include(token)
+          end
+        end
+      end
+
       context "with client.options[:raise_errors] = false" do
         let(:options) { {raise_errors: false} }
 


### PR DESCRIPTION
The [Instagram API ](https://developers.facebook.com/docs/instagram-platform/instagram-api-with-instagram-login) uses `:query` token mode for `GET` requests and `:header` mode for `POST` requests, not only for endpoint calls but for [getting](https://developers.facebook.com/docs/instagram-platform/reference/access_token) and [refreshing](https://developers.facebook.com/docs/instagram-platform/reference/refresh_access_token) long-lived tokens. So instead of a fixed mode, an `AccessToken` needs its mode to to be request-verb-dependent. This PR implement this.

Two things I haven't done:

1. Allow the mode to also be dependent on the path and even other options, and
2. Test an invalid mode. I couldn't work out how to stop RSpec using
```
block_is_expected.to raise_error("invalid :mode option of #{mode}")
````
from earlier in the spec file. Not that important given that the normal mode-switching works.