### PR TITLE
💚 cgi mostly removed from ruby-head, so add cgi as dev dependency

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -30,6 +30,8 @@ end
 # Used for head (nightly) releases of ruby, truffleruby, and jruby.
 # Split into discrete appraisals if one of them needs a dependency locked discretely.
 appraise "head" do
+  # Why is gem "cgi" here? See: https://github.com/vcr/vcr/issues/1057
+  gem "cgi", ">= 0.5"
   gem "benchmark", "~> 0.4", ">= 0.4.1"
   eval_gemfile "modular/runtime_heads.gemfile"
 end

--- a/gemfiles/head.gemfile
+++ b/gemfiles/head.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "cgi", ">= 0.5"
 gem "benchmark", "~> 0.4", ">= 0.4.1"
 
 gemspec path: "../"

--- a/oauth2.gemspec
+++ b/oauth2.gemspec
@@ -198,6 +198,9 @@ Thanks, @pboling / @galtzo
   # | # ./spec/spec_helper.rb:8:in `<top (required)>'
   # So that's why we need backports.
   spec.add_development_dependency("backports", "~> 3.25", ">= 3.25.1")  # ruby >= 0
-  spec.add_development_dependency("vcr", ">= 4")                      # 6.0 claims to support ruby >= 2.3, but fails on ruby 2.4
-  spec.add_development_dependency("webmock", ">= 3")                  # Last version to support ruby >= 2.3
+  # In Ruby 3.5 (HEAD) the CGI library has been pared down, so we also need to depend on gem "cgi" for ruby@head
+  # This is done in the "head" appraisal.
+  # See: https://github.com/vcr/vcr/issues/1057
+  spec.add_development_dependency("vcr", ">= 4")                        # 6.0 claims to support ruby >= 2.3, but fails on ruby 2.4
+  spec.add_development_dependency("webmock", ">= 3")                    # Last version to support ruby >= 2.3
 end


### PR DESCRIPTION
- in support of vcr: https://github.com/vcr/vcr/issues/1057