### PR TITLE
Use MultiXML constant to fix deprecation warning from multi_xml 0.9+

### DIFF
--- a/lib/oauth2/response.rb
+++ b/lib/oauth2/response.rb
@@ -171,7 +171,7 @@ end
 OAuth2::Response.register_parser(:xml, ["text/xml", "application/rss+xml", "application/rdf+xml", "application/atom+xml", "application/xml"]) do |body|
   next body unless body.respond_to?(:to_str)
 
-  MultiXml.parse(body)
+  (defined?(MultiXML) ? MultiXML : MultiXml).parse(body)
 end
 
 # Register JSON parser

--- a/spec/config/multi_xml.rb
+++ b/spec/config/multi_xml.rb
@@ -2,4 +2,4 @@
 
 require "multi_xml"
 
-MultiXml.parser = :rexml
+(defined?(MultiXML) ? MultiXML : MultiXml).parser = :rexml

--- a/spec/oauth2/client_spec.rb
+++ b/spec/oauth2/client_spec.rb
@@ -649,14 +649,14 @@ RSpec.describe OAuth2::Client do
     it "provides the response in the Exception" do
       expect { subject.request(:get, "/error") }.to raise_error do |ex|
         expect(ex.response).not_to be_nil
-        expect(ex.to_s).to match(/unknown error/)
+        expect(ex.to_s).to include("unknown error")
       end
     end
 
     it "informs about unhandled status code" do
       expect { subject.request(:get, "/unhandled_status") }.to raise_error do |ex|
         expect(ex.response).not_to be_nil
-        expect(ex.to_s).to match(/Unhandled status code value of 600/)
+        expect(ex.to_s).to include("Unhandled status code value of 600")
       end
     end
 
@@ -767,7 +767,8 @@ RSpec.describe OAuth2::Client do
           end
         end
 
-        expect { client.get_token(parse: :xml) }.to raise_error(MultiXml::ParseError)
+        xml_parse_error = defined?(MultiXML) ? MultiXML::ParseError : MultiXml::ParseError
+        expect { client.get_token(parse: :xml) }.to raise_error(xml_parse_error)
       end
     end
 


### PR DESCRIPTION
multi_xml 0.9.0 renamed the top-level constant from \`MultiXml\` to \`MultiXML\` and made the old name a deprecated shim that emits a warning on every method call:

\`\`\`
The MultiXml constant is deprecated and will be removed in v1.0. Use MultiXML instead.
\`\`\`

This uses \`defined?(MultiXML)\` to prefer the new constant when available (multi_xml >= 0.9), falling back to \`MultiXml\` on older versions. No minimum version bump required — the fix is fully backward compatible.